### PR TITLE
enable bubbling of the events `scrollSpy:enter` and `scrollSpy:exit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $.winSizeSpy().on('scrollSpy:winSize', funcy)
 
 # Contributions
 
-Please provide pull requests for additional features.  Test cases would be most weclome!
+Please provide pull requests for additional features.  Test cases would be most welcome!
 
 Thank you contributors:
 

--- a/scrollspy.js
+++ b/scrollspy.js
@@ -72,7 +72,7 @@
 			var lastTick = element.data('scrollSpy:ticks');
 			if (typeof lastTick != 'number') {
 				// entered into view
-				element.triggerHandler('scrollSpy:enter');
+				element.trigger('scrollSpy:enter');
 			}
 
 			// update tick id
@@ -84,7 +84,7 @@
 			var lastTick = element.data('scrollSpy:ticks');
 			if (typeof lastTick == 'number' && lastTick !== ticks) {
 				// exited from view
-				element.triggerHandler('scrollSpy:exit');
+				element.trigger('scrollSpy:exit');
 				element.data('scrollSpy:ticks', null);
 			}
 		});


### PR DESCRIPTION
Currently the events triggered by ScrollSpy **do not bubble** because they are triggered by the jQuery's `.triggerHandler` method which [(according to the docs)](http://api.jquery.com/triggerHandler/) is similar to `.trigger()` but one of the exceptions is the following:

> Events triggered with `.triggerHandler()` do not bubble up the DOM hierarchy; if they are not handled by the target element directly, they do nothing.

Unfortunately, for me it's an issue. Sometimes in my applications ([PhiDo](https://github.com/Mithgol/phido), for example) I have to initiate scrollspying on **hundreds** of elements. Installing a separate event handler on each of these elements (instead of **only one** handler on a parent element) seems superfluous.

Hence a pull request to replace `.triggerHandler` with a simple `.trigger`.

(Also fixes #8 because is based on its code branch.)
